### PR TITLE
feat: add detail/summary collapsible prompt component

### DIFF
--- a/_examples/detail/custom-indicators/main.go
+++ b/_examples/detail/custom-indicators/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/indaco/prompti/detail"
+)
+
+var detailConfig = &detail.Config{
+	Summary:            "Configuration Options",
+	Content:            "verbose: true\nlog_level: debug\nmax_retries: 3",
+	CollapsedIndicator: "[+]",
+	ExpandedIndicator:  "[-]",
+}
+
+func main() {
+	expanded, _ := detail.Run(detailConfig)
+	fmt.Println("expanded:", expanded)
+}

--- a/_examples/detail/custom-styles/main.go
+++ b/_examples/detail/custom-styles/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+
+	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/compat"
+	"github.com/indaco/prompti/detail"
+)
+
+var (
+	cyan   = compat.AdaptiveColor{Light: lipgloss.Color("#4f46e5"), Dark: lipgloss.Color("#c7d2fe")}
+	green  = compat.AdaptiveColor{Light: lipgloss.Color("#166534"), Dark: lipgloss.Color("#22c55e")}
+	red    = compat.AdaptiveColor{Light: lipgloss.Color("#ef4444"), Dark: lipgloss.Color("#ef4444")}
+	purple = compat.AdaptiveColor{Light: lipgloss.Color("#7e22ce"), Dark: lipgloss.Color("#a855f7")}
+
+	myCustomStyle = detail.Styles{
+		PrefixIcon:      "★",
+		PrefixIconColor: red,
+		SummaryStyle:    lipgloss.NewStyle().Bold(true).Foreground(purple).PaddingRight(1),
+		IndicatorStyle:  lipgloss.NewStyle().Foreground(green).PaddingRight(1),
+		ContentStyle:    lipgloss.NewStyle().Foreground(cyan).PaddingLeft(3).MarginTop(1),
+		DialogStyle:     lipgloss.NewStyle().Margin(1, 0),
+	}
+
+	detailConfig = &detail.Config{
+		Summary: "Release Notes v0.3.0",
+		Content: "- Added detail/summary component\n- Improved theme system\n- Bug fixes and performance improvements",
+		Styles:  myCustomStyle,
+	}
+)
+
+func main() {
+	expanded, _ := detail.Run(detailConfig)
+	fmt.Println("expanded:", expanded)
+}

--- a/_examples/detail/default/main.go
+++ b/_examples/detail/default/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/indaco/prompti/detail"
+)
+
+func main() {
+	expanded, err := detail.Run(&detail.Config{
+		Summary: "What is prompti?",
+		Content: "prompti is a collection of interactive terminal UI prompts\nbuilt on the charmbracelet bubbletea framework.",
+	})
+	fmt.Println("expanded:", expanded, "err:", err)
+}

--- a/_examples/detail/multiline-content/main.go
+++ b/_examples/detail/multiline-content/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/indaco/prompti/detail"
+)
+
+var detailConfig = &detail.Config{
+	Summary: "Error Details",
+	Content: `Status:  503 Service Unavailable
+Endpoint: /api/v1/users
+Trace ID: abc-123-def-456
+
+The upstream service did not respond within
+the configured timeout of 30 seconds.
+
+Suggested actions:
+  1. Check service health dashboard
+  2. Verify network connectivity
+  3. Review recent deployments`,
+}
+
+func main() {
+	expanded, _ := detail.Run(detailConfig)
+	fmt.Println("expanded:", expanded)
+}

--- a/detail/command.go
+++ b/detail/command.go
@@ -1,0 +1,73 @@
+package detail
+
+import (
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/indaco/prompti"
+)
+
+// Config represents the struct to configure the tui command.
+type Config struct {
+	Summary            string
+	Content            string
+	CollapsedIndicator string
+	ExpandedIndicator  string
+	// styles
+	Styles Styles
+}
+
+// setDefaults sets default values for Config if not present.
+func (cfg *Config) setDefaults() {
+	cfg.CollapsedIndicator = setCollapsedIndicator(cfg)
+	cfg.ExpandedIndicator = setExpandedIndicator(cfg)
+	cfg.Styles.setDefaults()
+}
+
+func (cfg *Config) initialModel() model {
+	return model{
+		summary:            cfg.Summary,
+		content:            cfg.Content,
+		expanded:           false,
+		collapsedIndicator: cfg.CollapsedIndicator,
+		expandedIndicator:  cfg.ExpandedIndicator,
+		styles:             cfg.Styles,
+	}
+}
+
+// Run provides a shell script interface for prompting a user with a
+// collapsible detail/summary section. It returns whether the detail
+// was expanded when the user quit.
+func Run(cfg *Config) (bool, error) {
+	c := *cfg
+	c.setDefaults()
+	p := tea.NewProgram(c.initialModel())
+	m, err := p.Run()
+
+	if err != nil {
+		return false, fmt.Errorf("unable to run detail: %w", err)
+	}
+
+	result := m.(model)
+	if result.quitting {
+		return result.expanded, prompti.ErrCancelled
+	}
+
+	return result.expanded, nil
+}
+
+// =================================================================
+
+func setCollapsedIndicator(cfg *Config) string {
+	if cfg.CollapsedIndicator == "" {
+		return collapsedIndicatorDefault
+	}
+	return cfg.CollapsedIndicator
+}
+
+func setExpandedIndicator(cfg *Config) string {
+	if cfg.ExpandedIndicator == "" {
+		return expandedIndicatorDefault
+	}
+	return cfg.ExpandedIndicator
+}

--- a/detail/command_test.go
+++ b/detail/command_test.go
@@ -1,0 +1,39 @@
+package detail
+
+import "testing"
+
+func TestSetCollapsedIndicator(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{"default", Config{}, "\u25b6"},
+		{"custom", Config{CollapsedIndicator: ">"}, ">"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := setCollapsedIndicator(&tt.cfg); got != tt.want {
+				t.Errorf("setCollapsedIndicator() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetExpandedIndicator(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{"default", Config{}, "\u25bc"},
+		{"custom", Config{ExpandedIndicator: "v"}, "v"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := setExpandedIndicator(&tt.cfg); got != tt.want {
+				t.Errorf("setExpandedIndicator() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/detail/example_test.go
+++ b/detail/example_test.go
@@ -1,0 +1,14 @@
+package detail_test
+
+import (
+	"fmt"
+
+	"github.com/indaco/prompti/detail"
+)
+
+func ExampleDefaultStyles() {
+	s := detail.DefaultStyles()
+	fmt.Println("PrefixIcon:", s.PrefixIcon)
+	// Output:
+	// PrefixIcon: ?
+}

--- a/detail/messages.go
+++ b/detail/messages.go
@@ -1,0 +1,20 @@
+package detail
+
+import (
+	"image/color"
+
+	"charm.land/lipgloss/v2"
+	"github.com/indaco/prompti/internal/theme"
+)
+
+var (
+	// messages
+	summaryMessage = func(icon string, iconColor color.Color, sStyle lipgloss.Style, iStyle lipgloss.Style, indicator string, summary string) string {
+		return lipgloss.NewStyle().Render(
+			lipgloss.JoinHorizontal(lipgloss.Center,
+				prefixIconStyle(iconColor).Render(icon),
+				sStyle.Render(theme.Whitespace),
+				iStyle.Render(indicator),
+				sStyle.Render(summary)))
+	}
+)

--- a/detail/model.go
+++ b/detail/model.go
@@ -1,0 +1,88 @@
+// Package detail provides a collapsible detail/summary prompt built on bubbletea.
+package detail
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/indaco/prompti/internal/theme"
+)
+
+type model struct {
+	summary  string
+	content  string
+	expanded bool
+	quitting bool
+	// strings
+	collapsedIndicator string
+	expandedIndicator  string
+	// styles
+	styles Styles
+}
+
+func (m model) Init() tea.Cmd { return nil }
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		return m, nil
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc", "q":
+			m.quitting = true
+			return m, tea.Quit
+		case "enter", "space":
+			m.expanded = !m.expanded
+		case "left", "h", "up", "k":
+			m.expanded = false
+		case "right", "l", "down", "j":
+			m.expanded = true
+		case "y":
+			m.quitting = true
+			m.expanded = true
+			return m, tea.Quit
+		case "n":
+			m.quitting = true
+			m.expanded = false
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m model) View() tea.View {
+	if m.quitting {
+		return tea.NewView("")
+	}
+
+	var indicator string
+	if m.expanded {
+		indicator = m.expandedIndicator
+	} else {
+		indicator = m.collapsedIndicator
+	}
+
+	header := summaryMessage(
+		m.styles.PrefixIcon,
+		m.styles.PrefixIconColor,
+		m.styles.SummaryStyle,
+		m.styles.IndicatorStyle,
+		indicator,
+		m.summary,
+	)
+
+	var ui string
+	if m.expanded {
+		content := m.styles.ContentStyle.Render(m.content)
+		ui = m.styles.DialogStyle.Render(
+			lipgloss.JoinVertical(lipgloss.Left, header, content))
+	} else {
+		ui = m.styles.DialogStyle.Render(header)
+	}
+
+	hint := m.styles.HintStyle.Render(hintMessage)
+	output := lipgloss.JoinVertical(lipgloss.Left, ui, hint)
+
+	return tea.NewView(lipgloss.NewStyle().Render(output))
+}
+
+var hintMessage = theme.Whitespace + "enter/space: toggle" + theme.Whitespace + theme.PromptMark + theme.Whitespace + "q/esc: quit"

--- a/detail/model_test.go
+++ b/detail/model_test.go
@@ -1,0 +1,236 @@
+package detail
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func testModel() model {
+	cfg := &Config{
+		Summary: "More info",
+		Content: "Here are the details.",
+	}
+	cfg.setDefaults()
+	return cfg.initialModel()
+}
+
+func keyPress(code rune, mod tea.KeyMod, text string) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: code, Mod: mod, Text: text}
+}
+
+func TestInitialExpanded_IsFalse(t *testing.T) {
+	m := testModel()
+	if m.expanded {
+		t.Error("expected initial expanded to be false")
+	}
+}
+
+func TestUpdate_Enter_TogglesExpanded(t *testing.T) {
+	m := testModel() // expanded starts false
+	msg := keyPress(tea.KeyEnter, 0, "")
+	updated, _ := m.Update(msg)
+	um := updated.(model)
+
+	if !um.expanded {
+		t.Error("expected expanded to be true after enter")
+	}
+	if um.quitting {
+		t.Error("expected quitting to be false after enter")
+	}
+
+	// Toggle again.
+	updated2, _ := um.Update(msg)
+	um2 := updated2.(model)
+	if um2.expanded {
+		t.Error("expected expanded to be false after second enter toggle")
+	}
+}
+
+func TestUpdate_Space_TogglesExpanded(t *testing.T) {
+	m := testModel()
+	msg := keyPress(' ', 0, " ")
+	updated, _ := m.Update(msg)
+	um := updated.(model)
+
+	if !um.expanded {
+		t.Error("expected expanded to be true after space")
+	}
+}
+
+func TestUpdate_Right_SetsExpanded(t *testing.T) {
+	m := testModel() // expanded starts false
+	msg := keyPress(tea.KeyRight, 0, "")
+	updated, _ := m.Update(msg)
+	um := updated.(model)
+
+	if !um.expanded {
+		t.Error("expected expanded to be true after right")
+	}
+}
+
+func TestUpdate_Left_CollapsesExpanded(t *testing.T) {
+	m := testModel()
+	m.expanded = true
+	msg := keyPress(tea.KeyLeft, 0, "")
+	updated, _ := m.Update(msg)
+	um := updated.(model)
+
+	if um.expanded {
+		t.Error("expected expanded to be false after left")
+	}
+}
+
+func TestUpdate_J_SetsExpanded(t *testing.T) {
+	m := testModel()
+	msg := keyPress('j', 0, "j")
+	updated, _ := m.Update(msg)
+	um := updated.(model)
+
+	if !um.expanded {
+		t.Error("expected expanded to be true after 'j'")
+	}
+}
+
+func TestUpdate_K_CollapsesExpanded(t *testing.T) {
+	m := testModel()
+	m.expanded = true
+	msg := keyPress('k', 0, "k")
+	updated, _ := m.Update(msg)
+	um := updated.(model)
+
+	if um.expanded {
+		t.Error("expected expanded to be false after 'k'")
+	}
+}
+
+func TestUpdate_Y_SetsExpandedTrue_Quitting(t *testing.T) {
+	m := testModel()
+	msg := keyPress('y', 0, "y")
+	updated, cmd := m.Update(msg)
+	um := updated.(model)
+
+	if !um.expanded {
+		t.Error("expected expanded to be true after 'y'")
+	}
+	if !um.quitting {
+		t.Error("expected quitting to be true after 'y'")
+	}
+	if cmd == nil {
+		t.Error("expected a non-nil quit command")
+	}
+}
+
+func TestUpdate_N_SetsExpandedFalse_Quitting(t *testing.T) {
+	m := testModel()
+	m.expanded = true
+	msg := keyPress('n', 0, "n")
+	updated, cmd := m.Update(msg)
+	um := updated.(model)
+
+	if um.expanded {
+		t.Error("expected expanded to be false after 'n'")
+	}
+	if !um.quitting {
+		t.Error("expected quitting to be true after 'n'")
+	}
+	if cmd == nil {
+		t.Error("expected a non-nil quit command")
+	}
+}
+
+func TestUpdate_CtrlC_SetsQuitting(t *testing.T) {
+	m := testModel()
+	msg := keyPress('c', tea.ModCtrl, "")
+	updated, cmd := m.Update(msg)
+	um := updated.(model)
+
+	if !um.quitting {
+		t.Error("expected quitting to be true after ctrl+c")
+	}
+	if cmd == nil {
+		t.Error("expected a non-nil quit command")
+	}
+}
+
+func TestUpdate_Esc_SetsQuitting(t *testing.T) {
+	m := testModel()
+	msg := keyPress(tea.KeyEscape, 0, "")
+	updated, cmd := m.Update(msg)
+	um := updated.(model)
+
+	if !um.quitting {
+		t.Error("expected quitting to be true after esc")
+	}
+	if cmd == nil {
+		t.Error("expected a non-nil quit command")
+	}
+}
+
+func TestUpdate_Q_SetsQuitting(t *testing.T) {
+	m := testModel()
+	msg := keyPress('q', 0, "q")
+	updated, cmd := m.Update(msg)
+	um := updated.(model)
+
+	if !um.quitting {
+		t.Error("expected quitting to be true after 'q'")
+	}
+	if cmd == nil {
+		t.Error("expected a non-nil quit command")
+	}
+}
+
+func TestView_Quitting_ReturnsEmpty(t *testing.T) {
+	m := testModel()
+	m.quitting = true
+	v := m.View()
+
+	if v.Content != "" {
+		t.Errorf("expected empty view content when quitting, got %q", v.Content)
+	}
+}
+
+func TestView_NotQuitting_ReturnsNonEmpty(t *testing.T) {
+	m := testModel()
+	v := m.View()
+
+	if v.Content == "" {
+		t.Error("expected non-empty view content when not quitting")
+	}
+}
+
+func TestView_Collapsed_DoesNotContainContent(t *testing.T) {
+	m := testModel()
+	m.expanded = false
+	v := m.View()
+
+	// The content text should not appear when collapsed.
+	if containsSubstring(v.Content, "Here are the details.") {
+		t.Error("expected collapsed view to not contain detail content")
+	}
+}
+
+func TestView_Expanded_ContainsContent(t *testing.T) {
+	m := testModel()
+	m.expanded = true
+	v := m.View()
+
+	if !containsSubstring(v.Content, "Here are the details.") {
+		t.Error("expected expanded view to contain detail content")
+	}
+}
+
+// containsSubstring is a helper to check if a string contains a substring.
+func containsSubstring(s, sub string) bool {
+	return len(s) >= len(sub) && searchSubstring(s, sub)
+}
+
+func searchSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/detail/styles.go
+++ b/detail/styles.go
@@ -1,0 +1,82 @@
+package detail
+
+import (
+	"image/color"
+
+	"charm.land/lipgloss/v2"
+	"github.com/indaco/prompti/internal/theme"
+)
+
+// Styles is the struct representing the style configuration options.
+type Styles struct {
+	PrefixIcon      string
+	PrefixIconColor color.Color
+	SummaryStyle    lipgloss.Style
+	IndicatorStyle  lipgloss.Style
+	ContentStyle    lipgloss.Style
+	DialogStyle     lipgloss.Style
+	HintStyle       lipgloss.Style
+}
+
+const (
+	questionMark              = theme.QuestionMark
+	collapsedIndicatorDefault = "\u25b6"
+	expandedIndicatorDefault  = "\u25bc"
+)
+
+var (
+	// Styles
+	prefixIconStyle = func(c color.Color) lipgloss.Style {
+		return lipgloss.NewStyle().Bold(true).Foreground(c).PaddingRight(1)
+	}
+	summaryStyle   = lipgloss.NewStyle().Bold(true).PaddingRight(1)
+	indicatorStyle = lipgloss.NewStyle().
+			Foreground(theme.Cyan).PaddingRight(1)
+	contentStyle = lipgloss.NewStyle().
+			Foreground(theme.Neutral).
+			PaddingLeft(3).
+			MarginTop(1)
+	dialogStyle = lipgloss.NewStyle()
+	hintStyle   = lipgloss.NewStyle().
+			Foreground(theme.Muted).
+			MarginTop(1)
+
+	defaultTheme = Styles{
+		PrefixIcon:      questionMark,
+		PrefixIconColor: theme.Purple,
+		SummaryStyle:    summaryStyle,
+		IndicatorStyle:  indicatorStyle,
+		ContentStyle:    contentStyle,
+		DialogStyle:     dialogStyle,
+		HintStyle:       hintStyle,
+	}
+)
+
+// DefaultStyles sets the default styles theme.
+func DefaultStyles() (s Styles) {
+	return defaultTheme
+}
+
+func (t *Styles) setDefaults() {
+	if t.PrefixIcon == "" {
+		t.PrefixIcon = defaultTheme.PrefixIcon
+	}
+	if t.PrefixIconColor == nil {
+		t.PrefixIconColor = defaultTheme.PrefixIconColor
+	}
+	if theme.IsZeroStyle(t.SummaryStyle) {
+		t.SummaryStyle = defaultTheme.SummaryStyle
+	}
+	if theme.IsZeroStyle(t.IndicatorStyle) {
+		t.IndicatorStyle = defaultTheme.IndicatorStyle
+	}
+	if theme.IsZeroStyle(t.ContentStyle) {
+		t.ContentStyle = defaultTheme.ContentStyle
+	}
+	if theme.IsZeroStyle(t.DialogStyle) {
+		t.DialogStyle = defaultTheme.DialogStyle
+	}
+	if theme.IsZeroStyle(t.HintStyle) {
+		t.HintStyle = defaultTheme.HintStyle
+	}
+}

--- a/detail/styles_test.go
+++ b/detail/styles_test.go
@@ -1,0 +1,72 @@
+package detail
+
+import (
+	"image/color"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/indaco/prompti/internal/theme"
+)
+
+func TestSetDefaults_ZeroValue(t *testing.T) {
+	var s Styles
+	s.setDefaults()
+
+	if s.PrefixIcon != defaultTheme.PrefixIcon {
+		t.Errorf("PrefixIcon: got %q, want %q", s.PrefixIcon, defaultTheme.PrefixIcon)
+	}
+	if s.PrefixIconColor == nil {
+		t.Error("PrefixIconColor should not be nil after setDefaults")
+	}
+	if theme.IsZeroStyle(s.SummaryStyle) {
+		t.Error("SummaryStyle should not be zero after setDefaults")
+	}
+	if theme.IsZeroStyle(s.IndicatorStyle) {
+		t.Error("IndicatorStyle should not be zero after setDefaults")
+	}
+	if theme.IsZeroStyle(s.ContentStyle) {
+		t.Error("ContentStyle should not be zero after setDefaults")
+	}
+	if theme.IsZeroStyle(s.HintStyle) {
+		t.Error("HintStyle should not be zero after setDefaults")
+	}
+}
+
+func TestSetDefaults_CustomValuesPreserved(t *testing.T) {
+	customIcon := ">>>"
+	customColor := color.RGBA{R: 0, G: 255, B: 0, A: 255}
+	customStyle := lipgloss.NewStyle().Italic(true)
+
+	s := Styles{
+		PrefixIcon:      customIcon,
+		PrefixIconColor: customColor,
+		SummaryStyle:    customStyle,
+		IndicatorStyle:  customStyle,
+		ContentStyle:    customStyle,
+		DialogStyle:     customStyle,
+		HintStyle:       customStyle,
+	}
+	s.setDefaults()
+
+	if s.PrefixIcon != customIcon {
+		t.Errorf("PrefixIcon: got %q, want %q", s.PrefixIcon, customIcon)
+	}
+	if s.PrefixIconColor != customColor {
+		t.Error("PrefixIconColor was overwritten")
+	}
+	if s.SummaryStyle.GetItalic() != true {
+		t.Error("SummaryStyle custom value was overwritten")
+	}
+	if s.IndicatorStyle.GetItalic() != true {
+		t.Error("IndicatorStyle custom value was overwritten")
+	}
+	if s.ContentStyle.GetItalic() != true {
+		t.Error("ContentStyle custom value was overwritten")
+	}
+	if s.DialogStyle.GetItalic() != true {
+		t.Error("DialogStyle custom value was overwritten")
+	}
+	if s.HintStyle.GetItalic() != true {
+		t.Error("HintStyle custom value was overwritten")
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -7,6 +7,7 @@
 //   - input: text input with optional validation
 //   - confirm: yes/no confirmation dialog
 //   - toggle: inline yes/no toggle
+//   - detail: collapsible detail/summary section
 //   - progressbar: animated progress bar
 //
 // Each sub-package exposes a Config struct and a Run function.


### PR DESCRIPTION
## Summary

- Add new `detail` package: a collapsible detail/summary TUI component (like HTML `<details>`)
- Toggle expand/collapse via Enter, Space, arrow keys, h/j/k/l
- Customizable indicators (default ▶/▼), styles, and prefix icon
- 4 examples: default, custom-styles, custom-indicators, multiline-content