### PR TITLE
ci: harden GitHub Actions workflows with zizmor recommendations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ on:
       - "go.sum"
   workflow_dispatch:
 
+permissions: {}
+
 env:
   GO_VERSION: "1.25"
 
@@ -22,9 +24,13 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -66,10 +72,14 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     needs: lint
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -96,10 +106,14 @@ jobs:
     name: test-race
     runs-on: ubuntu-latest
     needs: lint
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,15 +9,21 @@ on:
       - "go.sum"
   workflow_dispatch:
 
+permissions: {}
+
 env:
   GO_VERSION: "1.25"
 
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   release:
     types: [created]
 
+permissions: {}
+
 env:
   GO_VERSION: '1.25'
 
@@ -10,21 +12,25 @@ jobs:
   create-release-notes:
     name: release-notes
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     environment:
       name: Release
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.release.tag_name }}
-          name: ${{ github.event.release.tag_name }}
-          draft: false
-          prerelease: false
-          make_latest: 'true'
-          token: ${{ secrets.PROMPTI_TOKEN }}
-          body_path: ${{ github.workspace }}/.changes/${{ github.event.release.tag_name }}.md
-          generate_release_notes: false
+          persist-credentials: false
+
+      - name: Update Release
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ secrets.PROMPTI_TOKEN }}
+        run: |
+          gh release edit "$RELEASE_TAG" \
+            --title "$RELEASE_TAG" \
+            --draft=false \
+            --prerelease=false \
+            --latest \
+            --notes-file "${{ github.workspace }}/.changes/${RELEASE_TAG}.md"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,6 +19,8 @@ on:
       - "go.sum"
   workflow_dispatch:
 
+permissions: {}
+
 env:
   GO_VERSION: "1.25"
 
@@ -26,9 +28,13 @@ jobs:
   govulncheck:
     name: govulncheck
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
## Summary

- Add `permissions: {}` at workflow level and minimal job-level permissions across all workflows
- Add `persist-credentials: false` to all checkout steps
- Replace `softprops/action-gh-release` with `gh release` CLI in release workflow
- Fix template injection by passing `github.event.release.tag_name` via env var

 ## Context

Findings from [zizmor](https://docs.zizmor.sh/) static analysis on all workflow files (`ci.yml`, `coverage.yml`, `release.yml`, `security.yml`).

Remaining `unpinned-uses` findings are intentionally kept - tags preferred over SHA pinning.